### PR TITLE
Improved the wording of an error message

### DIFF
--- a/isaac_xml_validator.py
+++ b/isaac_xml_validator.py
@@ -233,7 +233,10 @@ def main():
     if total_error_count > 0:
         print_err(f"Found: {total_error_count} errors")
         if total_error_count != expected_error_count:
-            print_err("Expected error count was not reached!")
+            if total_error_count > expected_error_count:
+                print_err("Expected error count was exceeded!")
+            else:
+                print_err("Expected error count was not reached!")
             sys.exit(1)
     else:
         print_ok("No errors found.")


### PR DESCRIPTION
When the number of errors goes over the number expected, the program states:
```
Expected error count was not reached!
```
In this scenario, the error count was, in fact, reached. The issue is that the error count was exceeded.

To correct this, I've made it so that the messages for being over and under the expected error count are now seperate:
```python
if total_error_count != expected_error_count:
    if total_error_count > expected_error_count:
        print_err("Expected error count was exceeded!")
    else:
        print_err("Expected error count was not reached!")
    sys.exit(1)
```