### PR TITLE
Repentogon corrections

### DIFF
--- a/xsd/achievements.xsd
+++ b/xsd/achievements.xsd
@@ -5,7 +5,7 @@
             <xs:sequence>
                 <xs:element maxOccurs="unbounded" name="achievement">
                     <xs:complexType>
-                        <xs:attribute name="id" type="xs:unsignedShort" use="required" />
+                        <xs:attribute name="id" type="xs:unsignedShort" use="optional" />
                         <xs:attribute name="text" type="xs:string" use="required" />
                         <xs:attribute name="gfx" type="xsisaac:pngFile" use="required" />
                         <xs:attribute name="steam_name" type="xs:string" use="optional" />

--- a/xsd/challenges.xsd
+++ b/xsd/challenges.xsd
@@ -33,6 +33,8 @@
             <xs:attribute name="bigrange" type="xs:boolean" use="optional" />
             <xs:attribute name="secretpath" type="xs:boolean" use="optional" />
             <xs:attribute name="startingitems2" type="xs:string" use="optional" />
+            <!-- Repentogon -->
+            <xs:attribute name="hidden" type="xs:boolean" use="optional" />
           </xs:complexType>
         </xs:element>
       </xs:sequence>


### PR DESCRIPTION
This PR makes the following changes
- Made `achievements.xml` value `id` optional
  - Repentogon functionally replaces it with the `name` value, and it is therefore not used
- Added `challenges.xml` value `hidden` from Repentogon